### PR TITLE
Reorder middleware to fix unit-test failures.

### DIFF
--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -71,8 +71,12 @@ describe('explorer', function() {
         app.use(restUrlBase, loopback.rest());
         app.use('/explorer', explorer(app, { basePath: restUrlBase }));
       } else {
-        app.use(loopback.rest());
+        // LoopBack REST adapter owns the whole URL space and does not
+        // let other middleware handle same URLs.
+        // It's possible to circumvent this measure by installing
+        // the explorer middleware before the REST middleware.
         app.use('/explorer', explorer(app));
+        app.use(loopback.rest());
       }
       done();
     }


### PR DESCRIPTION
LoopBack REST adapter owns the whole URL space and does not let other middleware handle same URLs. It's possible to circumvent this measure by installing the explorer middleware before the REST middleware, which is what this pull request does.

/to: @ritch please review.

I am wondering if it makes sense to support both modes (REST at `/`, REST at `/api`) for the future, since all new loopback applications are going to mount the REST middleware at a subpath anyway.
