### PR TITLE
Use new loopback app features - app.restApiRoot, "start" event [DO NOT MERGE YET]

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,16 @@ function explorer(loopbackApplication, options) {
     });
   });
   app.use(loopback.static(STATIC_ROOT));
+
+  loopbackApplication.once('start', function() {
+    var baseUrl = 'http://' + this.get('host') + ':' + this.get('port');
+    // `app.route` is filled by `expressApp.use(route, app)`, i.e.
+    //   loopbackApplication.use('/explorer', explorer(loopbackApplication))
+    // sets `app.route = '/explorer'`
+    var explorerPath = app.route;
+    console.log('Browse your REST API at %s%s', baseUrl, explorerPath);
+  });
+
   return app;
 }
 

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -1,3 +1,4 @@
+var format = require('util').format;
 var loopback = require('loopback');
 var explorer = require('../');
 var request = require('supertest');
@@ -76,6 +77,27 @@ describe('explorer', function() {
           done();
         });
     });
+  });
+
+  it('reports correct explorer URL on app start', function() {
+    var messages = [];
+    console._log = console.log;
+    console.log = function() {
+      messages.push(format.apply(null, Array.prototype.slice.call(arguments)));
+    };
+
+    var app = loopback();
+    app.set('host', 'custom-host');
+    app.set('port', 12345);
+    app.use('/custom-api', loopback.rest());
+    app.use('/custom-explorer', explorer(app, { basePath: '/custom-root' }));
+    app.emit('start');
+
+    console.log = console._log;
+    delete console._log;
+
+    expect(messages).to.have.length(1);
+    expect(messages[0]).to.contain('http://custom-host:12345/custom-explorer');
   });
 
   function givenLoopBackAppWithExplorer(restUrlBase) {


### PR DESCRIPTION
Requires strongloop/loopback#123
Related to strongloop/loopback-workspace#34 and strongloop/loopback-workspace#35

We need to bump up the minimum loopback version in package.json before merging this change.

/to: @ritch 
/cc: @sam-github
