### PR TITLE
Fix up loopback.rest() model definition hack.

### DIFF
--- a/lib/route-helper.js
+++ b/lib/route-helper.js
@@ -88,10 +88,7 @@ var routeHelper = module.exports = {
       if (firstReturn.type === 'object') {
         firstReturn.type = classDef.name;
       } else if (firstReturn.type === 'array') {
-        firstReturn.type = 'array';
-        firstReturn.items = {
-          '$ref': classDef.name
-        };
+        firstReturn.type = [classDef.name];
       }
     }
 


### PR DESCRIPTION
In its previous form, array return types were being returned simply
as {type: 'array'}, with their `items` definition forgotten.
