### PR TITLE
Add models from relations

### DIFF
--- a/lib/class-helper.js
+++ b/lib/class-helper.js
@@ -28,7 +28,7 @@ var classHelper = module.exports = {
       basePath: opts.basePath,
       resourcePath: urlJoin('/', opts.resourcePath),
       apis: [],
-      models: modelHelper.generateModelDefinition(aClass)
+      models: modelHelper.generateModelDefinition(aClass.ctor, {})
     };
   },
   /**

--- a/lib/model-helper.js
+++ b/lib/model-helper.js
@@ -13,13 +13,18 @@ var modelHelper = module.exports = {
   /**
    * Given a class (from remotes.classes()), generate a model definition.
    * This is used to generate the schema at the top of many endpoints.
-   * @param  {Class} class Remote class.
-   * @return {Object}      Associated model definition.
+   * @param  {Class} modelClass Model class.
+   * @param {Object} definitions Model definitions
+   * @return {Object} Associated model definition.
    */
-  generateModelDefinition: function generateModelDefinition(aClass) {
-    var def = aClass.ctor.definition;
+  generateModelDefinition: function generateModelDefinition(modelClass, definitions) {
+    var def = modelClass.definition;
     var name = def.name;
-
+    var out = definitions || {};
+    if (out[name]) {
+      // The model is already included
+      return out;
+    }
     var required = [];
     // Don't modify original properties.
     var properties = _cloneDeep(def.properties);
@@ -47,12 +52,20 @@ var modelHelper = module.exports = {
       properties[key] = prop;
     });
 
-    var out = {};
     out[name] = {
       id: name,
       properties: properties,
       required: required
     };
+
+    // Generate model definitions for related models
+    for (var r in modelClass.relations) {
+      var rel = modelClass.relations[r];
+      generateModelDefinition(rel.modelTo, out);
+      if (rel.modelThrough) {
+        generateModelDefinition(rel.modelThrough, out);
+      }
+    }
     return out;
   },
 


### PR DESCRIPTION
/to @bajtos 
/cc @STRML

The PR adds related models into the Swagger spec so that REST operations for relations are correctly typed.
