### PR TITLE
Remove hidden properties from definition.

### DIFF
--- a/example/hidden.js
+++ b/example/hidden.js
@@ -1,0 +1,20 @@
+var loopback = require('loopback');
+var app = loopback();
+var explorer = require('../');
+var port = 3000;
+
+var User = loopback.Model.extend('user', {
+  username: 'string',
+  email: 'string',
+  sensitiveInternalProperty: 'string',
+}, {hidden: ['sensitiveInternalProperty']});
+
+User.attachTo(loopback.memory());
+app.model(User);
+
+var apiPath = '/api';
+app.use('/explorer', explorer(app, {basePath: apiPath}));
+app.use(apiPath, loopback.rest());
+console.log('Explorer mounted at localhost:' + port + '/explorer');
+
+app.listen(port);

--- a/lib/model-helper.js
+++ b/lib/model-helper.js
@@ -37,6 +37,12 @@ var modelHelper = module.exports = {
     Object.keys(properties).forEach(function(key) {
       var prop = properties[key];
 
+      // Hide hidden properties.
+      if (modelHelper.isHiddenProperty(def, key)) {
+        delete properties[key];
+        return;
+      }
+
       // Eke a type out of the constructors we were passed.
       prop = modelHelper.LDLPropToSwaggerDataType(prop);
 
@@ -82,6 +88,12 @@ var modelHelper = module.exports = {
       propType = 'array';
     }
     return propType;
+  },
+
+  isHiddenProperty: function(definition, propName) {
+    return definition.settings && 
+      Array.isArray(definition.settings.hidden) &&
+      definition.settings.hidden.indexOf(propName) !== -1;
   },
 
   // Converts a prop defined with the LDL spec to one conforming to the 

--- a/test/model-helper.test.js
+++ b/test/model-helper.test.js
@@ -117,10 +117,29 @@ describe('model-helper', function() {
       expect(defs).has.property('relatedModel');
     });
   });
+  describe('hidden properties', function() {
+    it('should hide properties marked as "hidden"', function() {
+      var aClass = createModelCtor({
+        visibleProperty: 'string',
+        hiddenProperty: 'string'
+      });
+      aClass.ctor.definition.settings = {
+        hidden: ['hiddenProperty']
+      };
+      var def = modelHelper.generateModelDefinition(aClass.ctor, {}).testModel;
+      expect(def.properties).to.not.have.property('hiddenProperty');
+      expect(def.properties).to.have.property('visibleProperty');
+    });
+  });
 });
 
 // Simulates the format of a remoting class.
 function buildSwaggerModels(model) {
+  var aClass = createModelCtor(model);
+  return modelHelper.generateModelDefinition(aClass.ctor, {}).testModel;
+}
+
+function createModelCtor(model) {
   Object.keys(model).forEach(function(name) {
     model[name] = {type: model[name]};
   });
@@ -132,7 +151,7 @@ function buildSwaggerModels(model) {
       }
     }
   };
-  return modelHelper.generateModelDefinition(aClass.ctor, {}).testModel;
+  return aClass;
 }
 
 function buildSwaggerModelsWithRelations(model) {


### PR DESCRIPTION
These really shouldn't show up in the model definition if they're completely internal.

For example, user models in my application have a number of internal flags identifying the role of the user, verification status, and so on, that are never delivered to the user - but they are named as part of model definitions in loopback-explorer.
