### PR TITLE
res.send deprecated - updated to res.status

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -102,7 +102,7 @@ function addRoute(app, uri, doc) {
       var host = headers.Host || headers.host;
       doc.basePath = req.protocol + '://' + host + initialPath;
     }
-    res.send(200, doc);
+    res.status(200).send(doc);
   });
 }
 


### PR DESCRIPTION
Used to get warning: 'express deprecated res.send(status, body): Use res.status(status).send(body) instead node_modules/loopback-explorer/lib/swagger.js:105:9'
