### PR TITLE
Add required swagger 1.2 items property for property type array

### DIFF
--- a/lib/model-helper.js
+++ b/lib/model-helper.js
@@ -104,12 +104,18 @@ var modelHelper = module.exports = {
     out.type = modelHelper.getPropType(out.type);
 
     if (out.type === 'array') {
-      var hasItemType = typeof prop.type !== 'string' && prop.type[0];
+      var hasItemType = Array.isArray(prop.type) && prop.type.length;
+      var arrayItem = hasItemType && prop.type[0];
 
-      if (hasItemType) {
-        var arrayProp = prop.type[0];
-        if (!arrayProp.type) arrayProp = {type: arrayProp};
-        out.items = modelHelper.LDLPropToSwaggerDataType(arrayProp);
+      if (arrayItem) {
+        if(typeof arrayItem === 'object') {
+          out.items = modelHelper.LDLPropToSwaggerDataType(arrayItem);
+        } else {
+          out.items = { type: modelHelper.getPropType(arrayItem) };
+        }
+      } else {
+        // NOTE: `any` is not a supported type in swagger 1.2
+        out.items = { type: 'any' };
       }
     } else if (out.type === 'date') {
       out.type = 'string';

--- a/test/model-helper.test.js
+++ b/test/model-helper.test.js
@@ -86,7 +86,10 @@ describe('model-helper', function() {
           array: []
         });
         var prop = def.properties.array;
-        expect(prop).to.eql({ type: 'array' });
+        expect(prop).to.eql({
+          type: 'array',
+          items: { type: 'any' }
+        });
       });
 
       it('converts [undefined] type', function() {
@@ -96,7 +99,7 @@ describe('model-helper', function() {
           array: [undefined]
         });
         var prop = def.properties.array;
-        expect(prop).to.eql({ type: 'array' });
+        expect(prop).to.eql({ type: 'array', items: { type: 'any' } });
       });
 
       it('converts "array" type', function() {
@@ -104,7 +107,7 @@ describe('model-helper', function() {
           array: 'array'
         });
         var prop = def.properties.array;
-        expect(prop).to.eql({ type: 'array' });
+        expect(prop).to.eql({ type: 'array', items: { type: 'any' } });
       });
     });
   });


### PR DESCRIPTION
/to @raymondfeng 

This patch ensures the `items` object is always available. The UI is breaking on the full-stack-example because this isn't always assigned. [See swagger docs for more info.](https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#433-data-type-fields)

On a side note, I don't think we are handling all of the supported LDL formats for type definition. This code really needs some refactoring. We should move LDL normalization into loopback or its own module. This way all code that interacts with LDL doesn't have to support all the weird forms of type definition:
- `Constructor`
- `[Constructor]`
- `"type"`
- `{ type: Constructor}`
- `[]`

... there are quite a few other combinations
