### PR TITLE
Fixed undefined modelClass when using polymorphic relations

### DIFF
--- a/lib/model-helper.js
+++ b/lib/model-helper.js
@@ -67,7 +67,9 @@ var modelHelper = module.exports = {
     // Generate model definitions for related models
     for (var r in modelClass.relations) {
       var rel = modelClass.relations[r];
-      generateModelDefinition(rel.modelTo, out);
+      if (rel.modelTo){
+        generateModelDefinition(rel.modelTo, out);
+      }
       if (rel.modelThrough) {
         generateModelDefinition(rel.modelThrough, out);
       }


### PR DESCRIPTION
When using polymorphic relations the through model has no relation to another model, hence the modelTo variable might be undefined or null.
