### PR TITLE
Use `dist` property from swagger-ui package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ var urlJoin = require('./lib/url-join');
 var _defaults = require('lodash.defaults');
 var express = require('express');
 var swagger = require('./lib/swagger');
-var SWAGGER_UI_ROOT = path.join(__dirname, 'node_modules', 
-  'swagger-ui', 'dist');
+var SWAGGER_UI_ROOT = require('swagger-ui').dist;
 var STATIC_ROOT = path.join(__dirname, 'public');
 
 module.exports = explorer;


### PR DESCRIPTION
This removes the hardcoded local `node_modules` lookup for swagger-ui,
which will break if the parent installs swagger-ui itself.

This is useful if, for example, the latest swagger-ui breaks
loopback-explorer, and the parent project wants to install a fixed
version in its root.
