### PR TITLE
Newest Swagger UI requires application/x-www-form-urlencoded.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -26,8 +26,8 @@ function Swagger(loopbackApplication, swaggerApp, opts) {
     swaggerVersion: '1.2',
     basePath: loopbackApplication.get('restApiRoot') || '/api',
     resourcePath: 'resources',
-    // Default consumes/produces to application/json
-    consumes: ['application/json'],
+    // Default consumes/produces
+    consumes: ['application/json', 'application/x-www-form-urlencoded'],
     produces: ['application/json'],
     version: getVersion()
   });


### PR DESCRIPTION
UI will fail to POST if this consumes type is not specified.
