### PR TITLE
swagger: allow cross-origin requests

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -12,6 +12,7 @@ var urlJoin = require('./url-join');
 var _defaults = require('lodash.defaults');
 var classHelper = require('./class-helper');
 var routeHelper = require('./route-helper');
+var cors = require('cors');
 
 /**
  * Create a remotable Swagger module for plugging into `RemoteObjects`.
@@ -37,6 +38,8 @@ function Swagger(loopbackApplication, swaggerApp, opts) {
   var adapter = remotes.handler('rest').adapter;
   var routes = adapter.allRoutes();
   var classes = remotes.classes();
+
+  setupCors(swaggerApp, remotes);
 
   // These are the docs we will be sending from the /swagger endpoints.
   var resourceDoc = generateResourceDoc(opts);
@@ -70,11 +73,18 @@ function Swagger(loopbackApplication, swaggerApp, opts) {
   });
 
   /**
-   * The topmost Swagger resource is a description of all (non-Swagger) 
-   * resources available on the system, and where to find more 
+   * The topmost Swagger resource is a description of all (non-Swagger)
+   * resources available on the system, and where to find more
    * information about them.
    */
   addRoute(swaggerApp, opts.resourcePath, resourceDoc, opts);
+}
+
+function setupCors(swaggerApp, remotes) {
+  var corsOptions = remotes.options && remotes.options.cors ||
+    { origin: true, credentials: true };
+
+  swaggerApp.use(cors(corsOptions));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
     "url": "https://github.com/strongloop/loopback-explorer/blob/master/LICENSE"
   },
   "dependencies": {
-    "swagger-ui": "~2.0.18",
+    "cors": "^2.4.2",
     "debug": "~1.0.3",
+    "express": "3.x",
     "lodash.clonedeep": "^2.4.1",
     "lodash.defaults": "^2.4.1",
-    "express": "3.x"
+    "swagger-ui": "~2.0.18"
   }
 }


### PR DESCRIPTION
Add CORS middleware to the swagger app.

Add a configuration option allowing developers to disable CORS.

See also https://github.com/strongloop/strong-studio/issues/390

/to @raymondfeng please review
/cc @seanbrookes 
