### PR TITLE
Sort endpoints by letter.

### DIFF
--- a/public/lib/loadSwaggerUI.js
+++ b/public/lib/loadSwaggerUI.js
@@ -27,7 +27,8 @@ $(function() {
         log(data);
       },
       docExpansion: 'none',
-      highlightSizeThreshold: 16384
+      highlightSizeThreshold: 16384,
+      sorter: 'alpha'
     });
 
     $('#explore').click(setAccessToken);


### PR DESCRIPTION
Merged from swagger-ui's index.html.

Previously, endpoints were sorted in the order they were defined.
