### PR TITLE
Add syntax highlighting styles & highlight threshold.

### DIFF
--- a/public/css/loopbackStyles.css
+++ b/public/css/loopbackStyles.css
@@ -21,6 +21,19 @@
   bottom: -30px;
 }
 
+/* JSON syntax highlighting */
+.json, .json .attribute {
+  color: black;
+}
+
+.json .value .string {
+  color: #800;
+}
+
+.json .value .number, .json .value .literal {
+  color: #080;
+}
+
 /* 
 FIXME: Separate the overrides from the rest of the styles, rather than override screen.css entirely.
 */

--- a/public/lib/loadSwaggerUI.js
+++ b/public/lib/loadSwaggerUI.js
@@ -26,7 +26,8 @@ $(function() {
         log('Unable to Load SwaggerUI');
         log(data);
       },
-      docExpansion: 'none'
+      docExpansion: 'none',
+      highlightSizeThreshold: 16384
     });
 
     $('#explore').click(setAccessToken);


### PR DESCRIPTION
Previously, highlighting classes were being added to the DOM but had no CSS
so the user just saw black - a lot of CPU usage for nothing.

These styles now attractively and minimally style resposes so long as
they are below a certain threshold, as well as model schemas.

The highlightSizeThreshold fixes the long hang users would
see when large responses were returned.
