### PR TITLE
package: update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "url": "https://github.com/strongloop/loopback-explorer/issues"
   },
   "devDependencies": {
-    "loopback": "1.x",
-    "mocha": "~1.20.1",
-    "supertest": "~0.13.0",
-    "chai": "~1.9.1"
+    "loopback": "^2.4.1",
+    "mocha": "^1.21.5",
+    "supertest": "~0.14.0",
+    "chai": "^1.9.1"
   },
   "license": {
     "name": "Dual MIT/StrongLoop",


### PR DESCRIPTION
Update devDependencies to use loopback 2.x instead of 1.x.

So far, we were running the tests against 1.x to ensure the new explorer works with the old loopback version too.

Now that loopback 2.x has been available for some time and is getting used more widely, it should be safe to stop running the tests against 1.x.

Ideally, we should run tests against all supported versions, but that IMO requires more effort that it's worth it.

/to @raymondfeng @ritch do you agree with me?
/cc @STRML 
