### PR TITLE
example: use PersistedModel instead of Model

### DIFF
--- a/example/simple.js
+++ b/example/simple.js
@@ -3,7 +3,7 @@ var app = loopback();
 var explorer = require('../');
 var port = 3000;
 
-var Product = loopback.Model.extend('product', {
+var Product = loopback.PersistedModel.extend('product', {
   foo: {type: 'string', required: true},
   bar: 'string',
   aNum: {type: 'number', min: 1, max: 10, required: true, default: 5}
@@ -14,6 +14,6 @@ app.model(Product);
 var apiPath = '/api';
 app.use('/explorer', explorer(app, {basePath: apiPath}));
 app.use(apiPath, loopback.rest());
-console.log('Explorer mounted at localhost:' + port + '/explorer');
+console.log('Explorer mounted at http://localhost:' + port + '/explorer');
 
 app.listen(port);


### PR DESCRIPTION
Use `PersistedModel` as a base for the Product model to ensure it has some methods to inspect in the explorer.
