### PR TITLE
swagger: honour X-Forwarded-Proto header

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -166,9 +166,9 @@ function addRoute(app, uri, doc, opts) {
     if (hasBasePath) {
       var headers = req.headers;
       // NOTE header names (keys) are always all-lowercase
+      var proto = headers['x-forwarded-proto'] || opts.protocol || req.protocol;
       var host = headers['x-forwarded-host'] || headers.host;
-      doc.basePath = (opts.protocol || req.protocol) + '://' +
-        host + initialPath;
+      doc.basePath = proto + '://' + host + initialPath;
     }
     res.status(200).send(doc);
   });

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -93,6 +93,18 @@ describe('swagger definition', function() {
           done();
         });
     });
+
+    it('respects X-Forwarded-Proto header (behind a proxy)', function(done) {
+      var app = givenAppWithSwagger();
+      getAPIDeclaration(app, 'products')
+        .set('X-Forwarded-Proto', 'https')
+        .end(function(err, res) {
+          if (err) return done(err);
+          var baseUrl = url.parse(res.body.basePath);
+          expect(baseUrl.protocol).to.equal('https:');
+          done();
+        });
+    });
   });
 
   describe('Model definition attributes', function() {


### PR DESCRIPTION
Improve the algorithm building `baseUrl` to honour `X-Forwarded-Proto` header when it is present.

Close #57 

See also https://github.com/shelbys/strong-remoting/commit/c049f134214e0c42ce65c77483feeb15df79b9d9

/to @raymondfeng 
/cc @shelbys 
