### PR TITLE
Remove model name from nickname, swagger spec understands op context.

### DIFF
--- a/lib/route-helper.js
+++ b/lib/route-helper.js
@@ -149,8 +149,10 @@ var routeHelper = module.exports = {
       // is specified in the first response message.
       operations: [{
         method: routeHelper.convertVerb(route.verb),
-        // [rfeng] Swagger UI doesn't escape '.' for jQuery selector
-        nickname: route.method.replace(/\./g, '_'),
+        // [strml] remove leading model name from op, swagger uses leading 
+        // path as class name so it remains unique between models.
+        // route.method is always #{className}.#{methodName}
+        nickname: route.method.replace(/.*?\./, ''),
         parameters: accepts,
         responseMessages: responseMessages,
         summary: typeConverter.convertText(route.description),

--- a/test/route-helper.test.js
+++ b/test/route-helper.test.js
@@ -185,11 +185,24 @@ describe('route-helper', function() {
       responseModel: 'ValidationError'
     });
   });
+
+  it('route nickname does not include model name.', function() {
+    var doc = createAPIDoc();
+    expect(doc.operations[0].nickname).to.equal('get');
+  });
+
+  it('route nickname with a period is shorted correctly', function() {
+    // Method is built by remoting to always be #{className}.#{methodName}
+    var doc = createAPIDoc({
+      method: 'test.get.me'
+    });
+    expect(doc.operations[0].nickname).to.eql('get.me');
+  });
 });
 
 // Easy wrapper around createRoute
 function createAPIDoc(def) {
-  return routeHelper.routeToAPIDoc(_defaults(def, {
+  return routeHelper.routeToAPIDoc(_defaults(def || {}, {
     path: '/test',
     verb: 'GET',
     method: 'test.get'


### PR DESCRIPTION
This removes the redundancy from paths in swagger-ui such as
`/api/user/user_login`. It will now be displayed simply as
`/api/user/login`.

This is consistent with how `nickname` is used in Swagger examples.
