### PR TITLE
Allow `uiDirs` to be defined as a String

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,13 @@ function explorer(loopbackApplication, options) {
   // In this way one could e.g. make changes to index.html without having
   // to worry about constantly pulling in JS updates.
   if (options.uiDirs) {
-    options.uiDirs.forEach(function(dir) {
-     app.use(express.static(dir));
-    });
+    if (typeof options.uiDirs === 'string') {
+      app.use(express.static(options.uiDirs));
+    } else if (Array.isArray(options.uiDirs)) {
+      options.uiDirs.forEach(function(dir) {
+        app.use(express.static(dir));
+      });
+    }
   }
 
   if (options.swaggerDistRoot) {

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -106,6 +106,37 @@ describe('explorer', function() {
     });
   });
 
+  describe('when specifying custom static file root directories', function() {
+    var app;
+    beforeEach(function() {
+      app = loopback();
+    });
+
+    it('should allow `uiDirs` to be defined as an Array', function(done) {
+      app.use('/explorer', explorer(app, {
+        uiDirs: [ path.resolve(__dirname, 'fixtures', 'dummy-swagger-ui') ]
+      }));
+
+      request(app).get('/explorer/')
+        .expect(200)
+        // expect the content of `dummy-swagger-ui/index.html`
+        .expect('custom index.html\n')
+        .end(done);
+    });
+
+    it('should allow `uiDirs` to be defined as an String', function(done) {
+      app.use('/explorer', explorer(app, {
+        uiDirs: path.resolve(__dirname, 'fixtures', 'dummy-swagger-ui')
+      }));
+
+      request(app).get('/explorer/')
+        .expect(200)
+        // expect the content of `dummy-swagger-ui/index.html`
+        .expect('custom index.html\n')
+        .end(done);
+    });
+  });
+
   function givenLoopBackAppWithExplorer(explorerBase) {
     return function(done) {
       var app = this.app = loopback();


### PR DESCRIPTION
See strongloop/loopback-explorer/issues/81