### PR TITLE
Made API doc of class use the http.path of the class if available

### DIFF
--- a/lib/class-helper.js
+++ b/lib/class-helper.js
@@ -23,11 +23,16 @@ var classHelper = module.exports = {
    * @return {Object}       API Declaration.
    */
   generateAPIDoc: function(aClass, opts) {
+    var resourcePath =  urlJoin('/', aClass.name);
+    if(aClass.http && aClass.http.path) {
+        resourcePath = aClass.http.path;
+    }
+
     return {
       apiVersion: opts.version,
       swaggerVersion: opts.swaggerVersion,
       basePath: opts.basePath,
-      resourcePath: urlJoin('/', opts.resourcePath),
+      resourcePath: urlJoin('/', resourcePath),
       apis: [],
       consumes: aClass.http.consumes || opts.consumes,
       produces: aClass.http.produces || opts.produces,

--- a/test/class-helper.test.js
+++ b/test/class-helper.test.js
@@ -12,12 +12,32 @@ describe('class-helper', function() {
 
     expect(doc.description).to.equal('line1\nline2');
   });
+
+  it('sets resourcePath from aClass.http.path', function() {
+    var doc = generateAPIDoc({}, 'otherPath');
+
+    expect(doc.resourcePath).to.equal('/otherPath');
+  });
+
+  it('sets resourcePath from aClass.name', function() {
+    var doc = generateAPIDoc({});
+
+    expect(doc.resourcePath).to.equal('/test');
+  });
 });
 
 // Easy wrapper around createRoute
 function generateResourceDocAPIEntry(def) {
-  return classHelper.generateResourceDocAPIEntry(_defaults(def, {
-    http: { path: '/test' },
-    ctor: { settings: { } },
-  }));
+    return classHelper.generateResourceDocAPIEntry(_defaults(def, {
+        http: { path: '/test' },
+        ctor: { settings: { } }
+    }));
+}
+
+function generateAPIDoc(def, httpPath) {
+    return classHelper.generateAPIDoc(_defaults(def, {
+        http: { path: httpPath || null },
+        name: 'test',
+        ctor: { settings: { } }
+    }), {resourcePath: 'resources'});
 }


### PR DESCRIPTION
Currently loopback-explorer sets the value of `resourcePath` to `opts.resourcePath` for each and every Model in the application that exposes a REST API.

In my understanding of the [API Declararion part](https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#52-api-declaration) of the Swagger 1.2 spec, this is not correct. 
The correct way would be for each Model to have it's own resourcePath since each Model has it's own API Declaration.

Moreover, the [Swagger Codegen](https://github.com/swagger-api/swagger-codegen) tool uses the value of `resourcePath` to organize the resources into classes (at least in Java). 
What this means is that with the current `loopback-explorer` implementation, the generated client code for the whole API exposed by the server, will be contained in one file (which in Java's case will be named in ${opts.resourcePath}.java). Obviously such an effect is undesirable. 

Finally you can see that the `petstore` sample application from Swagger uses a different value of `resourcePath` for each Model. You can verify this fact [here](https://github.com/swagger-api/swagger-codegen/tree/master/modules/swagger-codegen/src/test/resources/1_2/petstore-1.2).

