### PR TITLE
Remove unused external font "Droid Sans".

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>StrongLoop API Explorer</title>
-  <link href='https://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
   <link href='css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>


### PR DESCRIPTION
We are shipping a custom style that uses "Ubuntu" instead of "Droid
Sans", thus there is no need to download the "Droid Sans" font
from Google's CDN.

This change should improve explorer's loading time in the situations
where the external URL takes too long to load or cannot be loaded at
all, for example when running behind a restricting proxy.

Fix #74.

/to @raymondfeng or @STRML please review

I run the following two greps to verify that our custom style is overriding all references to  "Droid Sans":

```
grep font-family -r public node_modules/swagger-ui/dist
grep Droid -r public node_modules/swagger-ui/dist
```