### PR TITLE
Fix duplicate stylesheet issue

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,10 +3,8 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>StrongLoop API Explorer</title>
-  <link href='css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='css/screen.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='css/reset.css' media='screen,print' rel='stylesheet' type='text/css'/>
+  <link href='css/screen.css' media='screen,print' rel='stylesheet' type='text/css'/>
   <link href='css/loopbackStyles.css' rel='stylesheet' type='text/css'/>
   <script type="text/javascript" src="lib/shred.bundle.js"></script>
   <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>


### PR DESCRIPTION
Referring to  - https://github.com/strongloop/loopback-explorer/issues/85
reset.css and screen.css were duplicated in index.html, for "screen" and "print" media.

Removed the duplicate entries and provided "screen" and "print" as multiple media options for "media" attribute.

@bajtos, can you please review?