### PR TITLE
Allow submitting token input with empty value to remove token.

### DIFF
--- a/public/lib/loadSwaggerUI.js
+++ b/public/lib/loadSwaggerUI.js
@@ -64,6 +64,17 @@ $(function() {
         window.localStorage.setItem(lsKey, key);
       }
     }
+    // If submitted with an empty token, remove the current token. Can be 
+    // useful to intentionally remove authorization.
+    else {
+      log('removed accessToken.');
+      $('.accessTokenDisplay').text('Token Not Set.').removeClass('set');
+      $('.accessTokenDisplay').removeAttr('data-tooltip');
+      window.authorizations.remove('key');
+      if (window.localStorage) {
+        window.localStorage.removeItem(lsKey);
+      }
+    }
   }
 
   function onInputChange(e) {


### PR DESCRIPTION
By default in loopback, if a token is submitted via header or querystring, but it is invalid, the method will not be run.

Unfortunately this is also even true of the `/login` method. This causes the following broken workflow:

1. The user's token expires. This can happen over time (idle browser), or if the browser is re-opened and the token was saved in localStorage, or the user intentionally loggedout.
2. The user wants to get a valid token. The user submits to `/user/login` with credentials to get a new token.
3. The default `token` middleware refuses the request due to an invalid access token.

The user needs to be able to delete the current token so he/she can resubmit.

This PR allows submitting the text box with an empty value to remove the current token.