### PR TITLE
Update swagger.js

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -176,7 +176,7 @@ function addRoute(app, uri, doc, opts) {
       var headers = req.headers;
       // NOTE header names (keys) are always all-lowercase
       var proto = headers['x-forwarded-proto'] || opts.protocol || req.protocol;
-      var host = headers['x-forwarded-host'] || headers.host;
+      var host = headers['x-forwarded-host'] || opts.host || headers.host;
       doc.basePath = proto + '://' + host + initialPath;
     }
     res.status(200).send(doc);


### PR DESCRIPTION
This additional host option is required if the API runs on a different host than loopback-explorer.