### PR TITLE
Add options.omitProtocolInBaseUrl

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -176,8 +176,9 @@ function addRoute(app, uri, doc, opts) {
       var headers = req.headers;
       // NOTE header names (keys) are always all-lowercase
       var proto = headers['x-forwarded-proto'] || opts.protocol || req.protocol;
+      var prefix = opts.omitProtocolInBaseUrl ? '//' : proto + '://';
       var host = headers['x-forwarded-host'] || headers.host;
-      doc.basePath = proto + '://' + host + initialPath;
+      doc.basePath = prefix + host + initialPath;
     }
     res.status(200).send(doc);
   });

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -105,6 +105,20 @@ describe('swagger definition', function() {
           done();
         });
     });
+
+    it('supports options.omitProtocolInBaseUrl', function(done) {
+      var app = givenAppWithSwagger({ omitProtocolInBaseUrl: true });
+
+      var getReq = getAPIDeclaration(app, 'products');
+      getReq.end(function(err, res) {
+        if (err) return done(err);
+        var basePath = res.body.basePath;
+        expect(basePath).to.match(/^\/\//);
+        var parsed = url.parse(res.body.basePath);
+        expect(parsed.protocol).to.equal(null);
+        done();
+      });
+    });
   });
 
   describe('Model definition attributes', function() {


### PR DESCRIPTION
A follow-up for #95. When the new option is enabled, base path is always set to a protocol-relative URL.

/to @STRML @raymondfeng could one of you review please?
/cc @billinghamj