### PR TITLE
[SEMVER-MAJOR] Rework the module to a loopback component

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,41 @@ var Product = loopback.Model.extend('product');
 Product.attachTo(loopback.memory());
 app.model(Product);
 
-app.use('/explorer', explorer(app, {basePath: '/api'}));
 app.use('/api', loopback.rest());
+
+// Register explorer using component-centric API:
+explorer(app, { basePath: '/api', mountPath: '/explorer' });
+// Alternatively, register as a middleware:
+app.use('/explorer', explorer.routes(app, { basePath: '/api' }));
+
 console.log("Explorer mounted at localhost:" + port + "/explorer");
 
 app.listen(port);
+```
+
+## Upgrading from v1.x
+
+To upgrade your application using loopback-explorer version 1.x, just replace
+`explorer()` with `explorer.routes()` in your server script:
+
+```js
+var explorer = require('loopback-explorer');
+
+// v1.x - does not work anymore
+app.use('/explorer', explorer(app, options);
+// v2.x
+app.use('/explorer', explorer.routes(app, options));
+```
+
+In applications scaffolded by `slc loopback`, the idiomatic way is to register
+loopback-explorer via `component-config.json`:
+
+```json
+{
+  "loopback-explorer": {
+    "mountPath": "/explorer"
+  }
+}
 ```
 
 ## Advanced Usage
@@ -32,7 +62,7 @@ See [options](#options) for a description of these options:
 ```js
 // Mount middleware before calling `explorer()` to add custom headers, auth, etc.
 app.use('/explorer', loopback.basicAuth('user', 'password'));
-app.use('/explorer', explorer(app, {
+explorer(app, {
   basePath: '/custom-api-root',
   uiDirs: [
     path.resolve(__dirname, 'public'),
@@ -59,6 +89,12 @@ Options are passed to `explorer(app, options)`.
 > Sets the API's base path. This must be set if you are mounting your api
 > to a path different than '/api', e.g. with
 > `loopback.use('/custom-api-root', loopback.rest());
+
+`mountPath`: **String**
+
+> Default: `/explorer`
+
+> Set the path where to mount the explorer component.
 
 `protocol`: **String**
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "cors": "^2.7.1",
     "debug": "^2.2.0",
-    "express": "4.x",
     "lodash": "^3.10.0",
     "strong-swagger-ui": "^20.0.2"
   }

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -106,9 +106,9 @@ describe('explorer', function() {
     var app;
     beforeEach(function setupExplorerWithUiDirs() {
       app = loopback();
-      app.use('/explorer', explorer(app, {
+      explorer(app, {
         uiDirs: [ path.resolve(__dirname, 'fixtures', 'dummy-swagger-ui') ]
-      }));
+      });
     });
 
     it('overrides swagger-ui files', function(done) {
@@ -128,6 +128,27 @@ describe('explorer', function() {
     });
   });
 
+  describe('explorer.routes API', function() {
+    var app;
+    beforeEach(function() {
+      app = loopback();
+      var Product = loopback.PersistedModel.extend('product');
+      Product.attachTo(loopback.memory());
+      app.model(Product);
+    });
+
+    it('creates explorer routes', function(done) {
+      app.use('/explorer', explorer.routes(app));
+      app.use(app.get('restApiRoot') || '/', loopback.rest());
+
+      request(app)
+        .get('/explorer/config.json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end(done);
+    });
+  });
+
   describe('when specifying custom static file root directories', function() {
     var app;
     beforeEach(function() {
@@ -135,9 +156,9 @@ describe('explorer', function() {
     });
 
     it('should allow `uiDirs` to be defined as an Array', function(done) {
-      app.use('/explorer', explorer(app, {
+      explorer(app, {
         uiDirs: [ path.resolve(__dirname, 'fixtures', 'dummy-swagger-ui') ]
-      }));
+      });
 
       request(app).get('/explorer/')
         .expect(200)
@@ -147,9 +168,9 @@ describe('explorer', function() {
     });
 
     it('should allow `uiDirs` to be defined as an String', function(done) {
-      app.use('/explorer', explorer(app, {
+      explorer(app, {
         uiDirs: path.resolve(__dirname, 'fixtures', 'dummy-swagger-ui')
-      }));
+      });
 
       request(app).get('/explorer/')
         .expect(200)
@@ -172,7 +193,7 @@ describe('explorer', function() {
     Product.attachTo(loopback.memory());
     app.model(Product);
 
-    app.use(explorerBase || '/explorer', explorer(app));
+    explorer(app, { mountPath: explorerBase });
     app.use(app.get('restApiRoot') || '/', loopback.rest());
   }
 });

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -3,7 +3,6 @@
 var url = require('url');
 var urlJoin = require('../lib/url-join');
 var loopback = require('loopback');
-var express = require('express');
 var swagger = require('../lib/swagger');
 
 var request = require('supertest');
@@ -387,7 +386,7 @@ describe('swagger definition', function() {
   }
 
   function mountExplorer(app, options) {
-    var swaggerApp = express();
+    var swaggerApp = loopback();
     swagger(app, swaggerApp, options);
     app.use(app.get('explorerRoot') || '/explorer', swaggerApp);
     return app;


### PR DESCRIPTION
Rework the exported function to conform to the component convention:

    var loopback = require('loopback');
    var explorer = require('loopback-explorer');
    var app = loopback();
    explorer(app, options);

- drop dependency on express
- drop support for loopback 1.x
- add a new option "mountPath" to specify where to mount the explorer UI
  and swagger metadata

Close #21 

/to @raymondfeng @ritch please review
/cc @STRML 