### PR TITLE
Switch to strong swagger ui

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var urlJoin = require('./lib/url-join');
 var _defaults = require('lodash').defaults;
 var express = require('express');
 var swagger = require('./lib/swagger');
-var SWAGGER_UI_ROOT = require('swagger-ui').dist;
+var SWAGGER_UI_ROOT = require('strong-swagger-ui').dist;
 var STATIC_ROOT = path.join(__dirname, 'public');
 
 module.exports = explorer;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "debug": "~1.0.3",
     "express": "3.x",
     "lodash": "^2.4.1",
-    "swagger-ui": "~2.0.18"
+    "strong-swagger-ui": "^20.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
   <script src='lib/loadSwaggerUI.js' type="text/javascript"></script>
 </head>
 
-<body class="swagger-section">
+<body class="swagger-section standalone">
 <div id='header'>
   <div class="swagger-ui-wrap">
     <a id="logo">StrongLoop API Explorer</a>


### PR DESCRIPTION
1) Extract all CSS customizations from `screen.css` to `loopbackStyles.css`, so that we use swagger-ui styles and get all improvements made in the last two years. It took me a while to find the right base commit and get a reasonable diff, I ended up using https://github.com/swagger-api/swagger-ui/blob/e980cca6b4218290ce4e5ab22f129c735dbecb27/dist/css/screen.css

2) Replace the dependency on swagger-ui with strong-swagger-ui, which is StrongLoop's fork of swagger-ui v2.0.x with additional enhancements

3) Drop public/images/throbger.gif, use the one provided by strong-swagger-ui. This will make it easier to inline this particular file inside CSS via data-uri.

Connect to strongloop-internal/scrum-loopback#112

/to @raymondfeng @ritch please review
/cc @STRML FYI

BTW my intention is to release this change as a minor version. Please speak up now if you think it should be a major release.