### PR TITLE
Upgrade to strong-swagger-ui@21.0 (swagger-ui@2.1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var path = require('path');
 var urlJoin = require('./lib/url-join');
 var _defaults = require('lodash').defaults;
 var swagger = require('./lib/swagger');
-var SWAGGER_UI_ROOT = require('strong-swagger-ui').dist;
+var SWAGGER_UI_ROOT = require('strong-swagger-ui/index').dist;
 var STATIC_ROOT = path.join(__dirname, 'public');
 
 module.exports = explorer;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "cors": "^2.7.1",
     "debug": "^2.2.0",
     "lodash": "^3.10.0",
-    "strong-swagger-ui": "^20.0.2"
+    "strong-swagger-ui": "^21.0.0-dev.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,26 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>StrongLoop API Explorer</title>
-  <link href='css/reset.css' media='screen,print' rel='stylesheet' type='text/css'/>
-  <link href='css/screen.css' media='screen,print' rel='stylesheet' type='text/css'/>
-  <link href='css/loopbackStyles.css' rel='stylesheet' type='text/css'/>
-  <script type="text/javascript" src="lib/shred.bundle.js"></script>
+  <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/loopbackStyles.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='css/loopbackStyles.css' media='print' rel='stylesheet' type='text/css'/>
   <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
   <script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
   <script src='lib/jquery.wiggle.min.js' type='text/javascript'></script>
   <script src='lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='lib/handlebars-1.0.0.js' type='text/javascript'></script>
+  <script src='lib/handlebars-2.0.0.js' type='text/javascript'></script>
   <script src='lib/underscore-min.js' type='text/javascript'></script>
   <script src='lib/backbone-min.js' type='text/javascript'></script>
-  <script src='lib/swagger.js' type='text/javascript'></script>
   <script src='swagger-ui.js' type='text/javascript'></script>
   <script src='lib/highlight.7.3.pack.js' type='text/javascript'></script>
+  <script src='lib/marked.js' type='text/javascript'></script>
 
   <!-- enabling this will enable oauth2 implicit scope support -->
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>


### PR DESCRIPTION
This patch upgrades loopback-explorer to use strong-swagger-ui@21.0, which is based on swagger-ui@2.1 and supports Swagger Spec 2.0.

**Notes**

 - strong-swagger-ui@21.0 does not implement all customizations from v20.0 yet, I'll be working on that in follow-up pull requests.

 - For endpoints `GET /models`, the response model is not correctly rendered ATM. I suspect this is caused by #111 and/or #113, I'll be investigating the problem after this PR is landed.

Connect to strongloop-internal/scrum-loopback#412
Connect to strongloop/loopback-explorer#54

/to @raymondfeng @STRML please review