### PR TITLE
Register loopback-explorer to app

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,9 @@ explorer.routes = routes;
  */
 
 function explorer(loopbackApplication, options) {
-  var mountPath = options.mountPath || '/explorer';
-  loopbackApplication.use(mountPath, routes(loopbackApplication, options));
+  options = _defaults({}, options, { mountPath: '/explorer' });
+  loopbackApplication.use(options.mountPath, routes(loopbackApplication, options));
+  loopbackApplication.set('loopback-explorer', options);
 }
 
 function routes(loopbackApplication, options) {

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -12,6 +12,11 @@ describe('explorer', function() {
   describe('with default config', function() {
     beforeEach(givenLoopBackAppWithExplorer());
 
+    it('should register "loopback-explorer" to the app', function() {
+      expect(this.app.get('loopback-explorer'))
+      .to.have.property('mountPath', '/explorer');
+    });
+
     it('should redirect to /explorer/', function(done) {
       request(this.app)
         .get('/explorer')
@@ -49,6 +54,11 @@ describe('explorer', function() {
 
   describe('with custom explorer base', function() {
     beforeEach(givenLoopBackAppWithExplorer('/swagger'));
+
+    it('should register "loopback-explorer" to the app', function() {
+      expect(this.app.get('loopback-explorer'))
+      .to.have.property('mountPath', '/swagger');
+    });
 
     it('should serve correct swagger-ui config', function(done) {
       request(this.app)


### PR DESCRIPTION
This patch registers loopback-explorer to the app object with its
options, making its mountPath property available at
app.get('loopback-explorer').