### PR TITLE
Sort APIs and operations.

### DIFF
--- a/public/lib/loadSwaggerUI.js
+++ b/public/lib/loadSwaggerUI.js
@@ -16,6 +16,7 @@ $(function() {
 
   var accessToken;
   function loadSwaggerUi(config) {
+    var methodOrder = ['get', 'head', 'options', 'put', 'post', 'delete'];
     window.swaggerUi = new SwaggerUi({
       url: config.url || '/swagger/resources',
       apiKey: '',
@@ -48,7 +49,13 @@ $(function() {
       },
       docExpansion: 'none',
       highlightSizeThreshold: 16384,
-      sorter: 'alpha'
+      apisSorter: 'alpha',
+      operationsSorter: function(a, b) {
+        var pathCompare = a.path.localeCompare(b.path);
+        return pathCompare !== 0 ?
+          pathCompare :
+          methodOrder.indexOf(a.method) - methodOrder.indexOf(b.method);
+      }
     });
 
     $('#explore').click(setAccessToken);


### PR DESCRIPTION
This was working in 1.x but broke in 2.x due to an API change in swagger-ui.

Sorts APIs alphabetically.
Sorts operations alphabetically then by method.


![screen shot 2015-09-07 at 9 54 56 pm](https://cloud.githubusercontent.com/assets/1197375/9725487/60a2c252-55ab-11e5-902c-e4ffcec51b0b.jpg)